### PR TITLE
Default value can be empty in calender input field => defaultUnselect…

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ export class AppComponent {
                       shouldCloseOnBackdropClick: false,
                       hasBackDrop: false
                     }
+                    // defaultUnselect: true,
                     // cancelLabel: "Cancel",
                     // excludeWeekends:true,
                     // fromMinMax: {fromDate:fromMin, toDate:fromMax},

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -28,7 +28,8 @@ export class AppComponent implements OnInit {
       presets: this.presets,
       format: 'mediumDate',
       range: { fromDate: today, toDate: today },
-      applyLabel: 'Submit'
+      applyLabel: 'Submit',
+      // defaultUnselect: true,
       // excludeWeekends:true,
       // fromMinMax: {fromDate:fromMin, toDate:fromMax},
       // toMinMax: {fromDate:toMin, toDate:toMax},

--- a/src/app/modules/ngx-mat-drp/model/model.ts
+++ b/src/app/modules/ngx-mat-drp/model/model.ts
@@ -30,4 +30,5 @@ export interface NgxDrpOptions {
   placeholder?: string;
   startDatePrefix?: string;
   endDatePrefix?: string;
+  defaultUnselect?:boolean;
 }

--- a/src/app/modules/ngx-mat-drp/ngx-mat-drp/ngx-mat-drp.component.ts
+++ b/src/app/modules/ngx-mat-drp/ngx-mat-drp/ngx-mat-drp.component.ts
@@ -63,10 +63,12 @@ export class NgxMatDrpComponent implements OnInit, OnDestroy {
       this.selectedDateRangeChanged.emit(range);
     });
 
-    this.rangeStoreService.updateRange(
-      this.options.range.fromDate,
-      this.options.range.toDate
-    );
+    if(!this.options.defaultUnselect) {  
+      this.rangeStoreService.updateRange(
+        this.options.range.fromDate,
+        this.options.range.toDate
+      );
+    }
     this.changeDetectionRef.detectChanges();
   }
 


### PR DESCRIPTION
Please review the patch, With this patch we can let the input field to be empty.